### PR TITLE
Add Adler-32 benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-transform-runtime": "7.13.9",
     "@babel/preset-env": "7.13.9",
     "@babel/preset-react": "7.12.13",
+    "adler-32": "^1.3.0",
     "argon2-browser": "1.15.3",
     "argon2-wasm": "0.9.0",
     "argon2-wasm-pro": "1.1.0",

--- a/src/benchmark/adler32.worker.js
+++ b/src/benchmark/adler32.worker.js
@@ -1,0 +1,28 @@
+import Bench from './bench';
+import adler32 from 'adler-32';
+import { adler32 as wasmAdler32, createAdler32 } from 'hash-wasm';
+import { getVersion } from '../utils';
+let adler32Instance = null;
+
+const suite = new Bench([
+    { size: 32, divisor: 200 },
+    { size: 1 * 1024 * 1024, divisor: 1 },
+  ],
+  async () => {
+    adler32Instance = await createAdler32();
+  }
+);
+
+suite.addAsync(`hash-wasm ${getVersion('hash-wasm')} adler32()`, buf => {
+  return wasmAdler32(buf);
+});
+
+suite.addSync(`hash-wasm ${getVersion('hash-wasm')} createAdler32()`, (buf) => {
+  adler32Instance.init();
+  adler32Instance.update(buf);
+  return adler32Instance.digest();
+});
+
+suite.addSync(`adler-32 ${getVersion('adler-32')}`, buf => {
+  return (adler32.buf(buf) >>> 0).toString(16);
+});

--- a/src/workers.js
+++ b/src/workers.js
@@ -1,3 +1,4 @@
+import Adler32Worker from './benchmark/adler32.worker.js';
 import Argon2idWorker from './benchmark/argon2id.worker.js';
 import BLAKE2bWorker from './benchmark/blake2b.worker.js';
 import BLAKE3Worker from './benchmark/blake3.worker.js';
@@ -14,6 +15,10 @@ import PBKDF2Worker from './benchmark/pbkdf2.worker.js';
 import ScryptWorker from './benchmark/scrypt.worker.js';
 
 const workerData = [
+  {
+    name: 'adler32',
+    factory: Adler32Worker,
+  },
   {
     name: 'argon2id',
     factory: Argon2idWorker,


### PR DESCRIPTION
Adds a benchmark for the new Adler-32 hash function (against [NPM package adler-32](https://www.npmjs.com/package/adler-32)).

`package-lock.json` still needs to be updated to point to a new release of hash-wasm which includes adler-32 support, if that support gets merged.